### PR TITLE
Adding SonarQube

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 .DS_Store
 docker-compose.yml
 docker-compose-dev.yml
+.scannerwork
+sonar-project.properties
+.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,4 @@
 docker-compose.yml
 docker-compose-dev.yml
 .scannerwork
-sonar-project.properties
 .vscode

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,5 +2,6 @@
     "cSpell.words": [
         "kensington"
     ],
-    "php.suggest.basic": false
+    "php.suggest.basic": false,
+    "git.ignoreLimitWarning": true
 }

--- a/capistrano.md
+++ b/capistrano.md
@@ -1,0 +1,1 @@
+# Using Capistrano to deploy to remote server.

--- a/octobercms/plugins/radiantweb/proevents/updates/create_events_table.php
+++ b/octobercms/plugins/radiantweb/proevents/updates/create_events_table.php
@@ -30,7 +30,7 @@ class CreateEventsTable extends Migration
             $table->text('status')->nullable();
             $table->timestamps();
         });
-        
+
         Schema::create('radiantweb_generated_dates', function($table)
         {
             $table->engine = 'InnoDB';

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,6 @@
+sonar.projectKey=kensington-cms 
+sonar.sources=./octobercms/plugins,./octobercms/themes,./api/app
+sonar.host.url=http://localhost:9000 
+sonar.login=66776b5afe5b0d70ca3c90246dcbef6f0c4bdfe6
+# Language (Only when it is a single language)
+sonar.language=php


### PR DESCRIPTION
Adding sonar project properties file

* In order to run the sonarqube scanner you need to pass some values before running `solar-scanner` from project root.

This change addresses the need by:

* Added some demo properties to sonar-project.properties.
* Before running a scan make sure to start up docker-container and initalizing new project