### PR TITLE
Added proEvents component markup to theme partials

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -17,6 +17,7 @@
 ### Other Links
 
 * [Search bar](search/README.md)
+* [Seeding with routes](seeding/README.md)
 * [Page Restrictions](unsorted/PageRestriction.md)
 * [Back-End Forms](backend/forms.md)
 * [Front-End Forms](unsorted/Forms.md)

--- a/docs/seeding/README.md
+++ b/docs/seeding/README.md
@@ -1,0 +1,58 @@
+# Seeding
+
+## Seeding with routes
+In a plugin you are able to seed a database with a Routes.php file. 
+
+    .octobercms
+    |-> plugins
+        |-> thiagoprado
+            |-> services
+                |-> components
+                |-> controllers
+                |-> formwidgets
+                |-> lang
+                |-> models
+                |-> updates
+                |-> Plugin.php
+                |-> plugin.yaml
+                |-> Routes.php  // Code goes here
+
+
+The following code uses this demo plugins `Expection` and `Clinic` models to seed 10 clinics and expectations using faker plugin as an example. This does not tear down the current database.
+
+```php
+<?php
+use ThiagoPrado\Services\Models\Expectation;
+use ThiagoPrado\Services\Models\Clinic;
+
+Route::get('seed-expectations', function () {
+    $faker = Faker\Factory::create();
+    for ($i = 0; $i < 10; $i++) {
+        $name = $faker->sentence($nbWords = 3, $variableNbWoeds = true);
+        $description = $faker->paragraph($nbSentences = 3, $variableNbSentences = true);
+
+        Expectation::create([
+            'name' => $name,
+            'description' => $description,
+        ]);
+    }
+
+    return "Expectations Seeded!";
+});
+
+Route::get('seed-clinics', function () {
+    $faker = Faker\Factory::create();
+    for ($i = 0; $i < 10; $i++) {
+        $clinic = $faker->sentence($nbWords = 3, $variableNbWoeds = true);
+
+        Clinic::create([
+            'clinic_title' => $clinic,
+            'slug' => str_slug($clinic, '-'),
+        ]);
+    }
+
+    return "Clinics Seeded!";
+});
+
+?>
+```

--- a/octobercms/themes/prismify-bootstrap-starter-kit/pages/events.htm
+++ b/octobercms/themes/prismify-bootstrap-starter-kit/pages/events.htm
@@ -7,5 +7,6 @@ is_hidden = 0
 eventpage = "event"
 style = "jquery_fullcalendar"
 calendar = "all_calendars"
+ical = 1
 ==
 {% component 'proEventCalendar' %}

--- a/octobercms/themes/prismify-bootstrap-starter-kit/partials/proEventCalendar/default.htm
+++ b/octobercms/themes/prismify-bootstrap-starter-kit/partials/proEventCalendar/default.htm
@@ -1,0 +1,1 @@
+{% partial "@" ~ event_calendar_view %}

--- a/octobercms/themes/prismify-bootstrap-starter-kit/partials/proEventCalendar/jquery_fullcalendar.htm
+++ b/octobercms/themes/prismify-bootstrap-starter-kit/partials/proEventCalendar/jquery_fullcalendar.htm
@@ -1,0 +1,58 @@
+<br/>
+<div id='calendar' data-request="getMonthsEvents" data-request-success="console.log(data)"></div>
+<!-- {% put scripts %} -->
+<script type="text/javascript">
+//<![CDATA[
+$(document).ready(function() {
+    // page is now ready, initialize the calendar...
+    $('#calendar').fullCalendar({
+        // put your options and callbacks here
+        customButtons: {
+            myCustomButton: {
+                text: 'custom!',
+                click: function () {
+                    alert('clicked the custom button!');
+                }
+            }
+        },
+        header: {
+            left: 'prev,next today myCustomButton',
+            center: 'title',
+            right: 'month,basicWeek,agendaDay,agendaList'
+        },
+        timeFormat: 'h:mm a\n',
+        displayEventEnd: true,
+        firstDay: 0,
+        showAgendaButton: true,
+        editable: false,
+        events: function(start, end, timezone, callback) {
+            $.request('{{__SELF__}}::onGetMonthEvents', {
+                data: {
+                    start: start.toJSON(),
+                    end: end.toJSON()
+                },
+                success: function(data){
+                    var events = $.parseJSON(data.result);
+                    callback(events);
+                }
+            })
+        },
+        eventRender: function(event, element) {
+            if (event.description) {
+                element.qtip({
+                    content: event.description,
+                    position: {
+                        target: 'mouse',
+                        // adjust: {
+                        //     mouse: false  // Can be omitted (e.g. default behaviour)
+                        // }
+                    },
+                    style: { classes: 'qtip-dark qtip-shadow qtip-rounded qtip-tipsy' }
+                });
+            }
+        }
+    })
+});
+//]]>
+</script>
+<!-- {% endput %} -->

--- a/octobercms/themes/prismify-bootstrap-starter-kit/partials/proEventCalendar/responsive.htm
+++ b/octobercms/themes/prismify-bootstrap-starter-kit/partials/proEventCalendar/responsive.htm
@@ -1,0 +1,68 @@
+<div class="loader"></div>
+<input type="hidden" value="0" id="cur_date"/>
+<form
+	data-request="{{ __SELF__ }}::listEvents"
+    data-request-update="'{{__SELF__}}::responsive_ajax': '#responsive_cal'"
+    data-request-success="$('#input-item').val('')"
+	class="event_nav">
+	<a
+		data-request = "{{ __SELF__ }}::onPrevMonth"
+    	data-request-update = "'{{__SELF__}}::responsive_ajax': '#responsive_cal'"
+    	data-request-data = "cal_date: $('#curent_date').val()"
+    	data-request-success = "$('#setyear').val($('#year').val());$('#setmo').val($('#month').val());"
+    	class = "button white submo"
+    	>&laquo;</a>
+	&nbsp;
+	<select name="setyear" id="setyear"
+		data-request = "{{ __SELF__ }}::onSetYear"
+    	data-request-update = "'{{__SELF__}}::responsive_ajax': '#responsive_cal'"
+    	data-request-data = "cal_date: $('#setyear').val() + '-' + $('#setmo').val() + '-01'"
+	>
+		<option value="{{ year - 2 }}">{{ year - 2 }}</option>
+		<option value="{{ year - 1 }}">{{ year - 1 }}</option>
+		<option value="{{ year }}" selected >{{ year }}</option>
+		<option value="{{ year + 1 }}">{{ year + 1 }}</option>
+		<option value="{{ year + 2 }}">{{ year + 2 }}</option>
+	</select>
+	<select name="setmo" id="setmo"
+		data-request = "{{ __SELF__ }}::onSetMonth"
+    	data-request-update = "'{{__SELF__}}::responsive_ajax': '#responsive_cal'"
+    	data-request-data = "cal_date: $('#setyear').val() + '-' + $('#setmo').val() + '-01'"
+	>
+		<option value="01" {% if month == 01 %} selected {% endif %}>{{'Jan'|_}}</option>
+		<option value="02" {% if month == 02 %} selected {% endif %}>{{'Feb'|_}}</option>
+		<option value="03" {% if month == 03 %} selected {% endif %}>{{'Mar'|_}}</option>
+		<option value="04" {% if month == 04 %} selected {% endif %}>{{'Apr'|_}}</option>
+		<option value="05" {% if month == 05 %} selected {% endif %}>{{'May'|_}}</option>
+		<option value="06" {% if month == 06 %} selected {% endif %}>{{'Jun'|_}}</option>
+		<option value="07" {% if month == 07 %} selected {% endif %}>{{'Jul'|_}}</option>
+		<option value="08" {% if month == 08 %} selected {% endif %}>{{'Aug'|_}}</option>
+		<option value="09" {% if month == 09 %} selected {% endif %}>{{'Sep'|_}}</option>
+		<option value="10" {% if month == 10 %} selected {% endif %}>{{'Oct'|_}}</option>
+		<option value="11" {% if month == 11 %} selected {% endif %}>{{'Nov'|_}}</option>
+		<option value="12" {% if month == 12 %} selected {% endif %}>{{'Dec'|_}}</option>
+	</select>
+
+	<input type="hidden" name="dateset" value="1">
+	&nbsp;
+	<a
+		data-request ="{{ __SELF__ }}::onNextMonth"
+    	data-request-update ="'{{__SELF__}}::responsive_ajax': '#responsive_cal'"
+    	data-request-data = "cal_date: $('#curent_date').val()"
+    	class="button white addmo"
+    	data-request-success = "$('#setyear').val($('#year').val());$('#setmo').val($('#month').val());"
+    	>&raquo;</a>
+</form>
+
+<div class="calendar" id="responsive_cal">
+	{% partial  __SELF__ ~ "::responsive_ajax" %}
+</div>
+{% put scripts %}
+<script type="text/javascript">
+    $(document).ready(function(){
+        setToolTips();
+        equalHeights(130,600);
+    });
+</script>
+{% endput %}
+<br style="clear: both;"/>

--- a/octobercms/themes/prismify-bootstrap-starter-kit/partials/proEventCalendar/responsive_ajax.htm
+++ b/octobercms/themes/prismify-bootstrap-starter-kit/partials/proEventCalendar/responsive_ajax.htm
@@ -1,0 +1,98 @@
+	<div class="title_year"><h3>{{ cal_date|date('F') }} {{year}}</h3></div>
+	<input type="hidden" id="curent_date" value="{{ cal_date }}" />
+	<input type="hidden" id="year" value="{{ year }}" />
+	<input type="hidden" id="month" value="{{ month }}" />
+	{% if euro_cal == 1 %}
+	    <ul class="weekdays">
+	        <li>{{'Monday'|_}}</li>
+	        <li>{{'Tuesday'|_}}</li>
+	        <li>{{'Wednesday'|_}}</li>
+	        <li>{{'Thursday'|_}}</li>
+	        <li>{{'Friday'|_}}</li>
+	        <li>{{'Saturday'|_}}</li>
+	        <li>{{'Sunday'|_}}</li>
+	    </ul>
+	{% else %}
+	    <ul class="weekdays">
+	        <li>{{'Sunday'|_}}</li>
+	        <li>{{'Monday'|_}}</li>
+	        <li>{{'Tuesday'|_}}</li>
+	        <li>{{'Wednesday'|_}}</li>
+	        <li>{{'Thursday'|_}}</li>
+	        <li>{{'Friday'|_}}</li>
+	        <li>{{'Saturday'|_}}</li>
+	    </ul>
+	{% endif %}
+	<ul class="days">
+		{% set daycount = 1 %}
+
+		{% if blank != 0 %}
+			{% for i in 1..blank %}
+			    <li class="calendar-day date_fill"><div class="date"></div></li>
+			    {% set daycount = daycount + 1 %}
+			{% endfor %}
+		{% endif %}
+
+		{% for i in 1..days_in_month %}
+			{% set daynum = year ~ '-' ~ month ~ '-' ~ i %}
+			<li class="calendar-day">
+				<div class="date"><span class="day"> {{ daynum|date("D") }} </span> <span class="month"> {{ daynum|date("M") }} </span> {{i}} </div>
+				{% for event_item in events %}
+					{% if daynum|date("Y-m-d") == event_item.event_date|date("Y-m-d") %}
+						<div class="daynum hasevent">
+							{% if event_item.status == 'booked' %}
+								{% set event_color = 'FF5050' %}
+							{% elseif event_item.status == 'available' %}
+								{% set event_color = '2EB82E' %}
+							{% else %}
+								{% set event_color = calendar_colors[event_item.calendar_id] %}
+							{% endif %}
+							{% if event_color %}<div style="background-color: #{{ event_color }}!important;" class="category_color">{% endif %}
+							<a href="{{ eventpage|page({'event_slug': event_item.title|replace({' ':'-'})|lower,'event_id': event_item.id }) }}/" rel="pe_tooltip" onClick="$('#pe_tooltip').remove();">
+								{% if event_item.status == 'booked' %}
+									<i class="icon-remove-sign"></i>
+								{% elseif event_item.status == 'available' %}
+									<i class="icon-ok-sign"></i>
+								{% endif %}
+								{{ event_item.title }}
+							</a>
+							<div class="pe_tooltip_body" style="display: none;">
+								<h4>{{ event_item.title }}</h4>
+								<!-- {% if event_item.event.featured_images[0]['path'] %}
+				                    <p><img src="{{event_item.event.featured_images[0]['path']}}" alt="event_{{event_item.id}}" width="100%" /></p>
+				                {% endif %} -->
+								<h5>{{ event_item.date|date("M dS") }}</h5>
+								{% if event_item.allday > 0 %}
+									{{'All Day'|_}}
+								{% else %}
+									{{ event_item.sttime|date("g:i a") }}  - {{ event_item.entime|date("g:i a") }}
+								{% endif %}
+							</div>
+							{% if event_color %}</div>{% endif %}
+						</div>
+					{% endif %}
+				{% endfor %}
+			</li>
+			{% set daycount = daycount + 1 %}
+			{% if daycount > 7 %}
+				</ul><ul class="days">
+				{% set daycount = 1 %}
+			{% endif %}
+		{% endfor %}
+
+		{% if (daycount - 7) > 0 %}
+			{% for i in i..(daycount - 7) %}
+				<li class="calendar-day date_fill"><div class="date"></div></li>
+				{% set daycount = daycount + 1 %}
+			{% endfor %}
+		{% elseif (daycount - 7) == 0 %}
+			<li class="calendar-day date_fill"><div class="date"></div></li>
+		{% endif %}
+	</ul>
+
+	<script type="text/javascript">
+    $(document).ready(function(){
+        setToolTips();
+        equalHeights(130,600);
+    });
+	</script>

--- a/octobercms/themes/prismify-bootstrap-starter-kit/partials/proEventCalendar/smallcal.htm
+++ b/octobercms/themes/prismify-bootstrap-starter-kit/partials/proEventCalendar/smallcal.htm
@@ -1,0 +1,56 @@
+<div class="calendar" id="small_cal_load">
+	<table  class='small_cal'>
+		<thead>
+			<tr>
+				<th class='select'>
+					<a class="button"
+						data-request = "{{ __SELF__ }}::onPrevMonth"
+		    			data-request-update = "'{{__SELF__}}::smallcal_ajax': '#small_cal_ajax_load'"
+		    			data-request-data = "cal_date: $('#curent_date').val()"
+		    			data-request-success = "$('#small_cal_year').html($('#cal_title').val());"
+		    			class = "button white submo"
+					>
+						<span class="icon-circle-arrow-left"></span>
+					</a>
+				</th>
+				<th colspan=5 id="small_cal_year" align='center'>{{ cal_date|date('F') }} {{year}}</th>
+				<th>
+					<a class="button" style="float: right;"
+						data-request = "{{ __SELF__ }}::onNextMonth"
+		    			data-request-update = "'{{__SELF__}}::smallcal_ajax': '#small_cal_ajax_load'"
+		    			data-request-data = "cal_date: $('#curent_date').val()"
+		    			data-request-success = "$('#small_cal_year').html($('#cal_title').val());"
+		    			class = "button white addmo"
+					>
+						<span class="icon-circle-arrow-right"></span>
+					</a>
+				</th>
+			</tr>
+
+			{% if euro_cal == 1 %}
+				<tr class="header">
+			        <td>{{'Mon'|_}}</td>
+			        <td>{{'Tue'|_}}</td>
+			        <td>{{'Wed'|_}}</td>
+			        <td>{{'Thu'|_}}</td>
+			        <td>{{'Fri'|_}}</td>
+			        <td>{{'Sat'|_}}</td>
+			        <td>{{'Sun'|_}}</td>
+			    </tr>
+			{% else %}
+			    <tr class="header">
+			    	<td>{{'Sun'|_}}</td>
+			        <td>{{'Mon'|_}}</td>
+			        <td>{{'Tue'|_}}</td>
+			        <td>{{'Wed'|_}}</td>
+			        <td>{{'Thu'|_}}</td>
+			        <td>{{'Fri'|_}}</td>
+			        <td>{{'Sat'|_}}</td>
+			    </tr>
+			{% endif %}
+		</thead>
+		<tbody id="small_cal_ajax_load">
+			{% partial  __SELF__ ~ "::smallcal_ajax" %}
+		</tbody>
+	</table>
+</div>

--- a/octobercms/themes/prismify-bootstrap-starter-kit/partials/proEventCalendar/smallcal_ajax.htm
+++ b/octobercms/themes/prismify-bootstrap-starter-kit/partials/proEventCalendar/smallcal_ajax.htm
@@ -1,0 +1,75 @@
+
+
+	<tr>
+		<input type="hidden" id="curent_date" value="{{ cal_date }}" />
+		<input type="hidden" id="cal_title" value="{{ cal_title }}" />
+		<input type="hidden" id="year" value="{{ year }}" />
+		<input type="hidden" id="month" value="{{ month }}" />
+		{% set daycount = 1 %}
+
+		{% if blank != 0 %}
+			{% for i in 1..blank %}
+			    <td class='cal_blank'></td>
+			    {% set daycount = daycount + 1 %}
+			{% endfor %}
+		{% endif %}
+
+		{% for i in 1..days_in_month %}
+			{% set daynum = year ~ '-' ~ month ~ '-' ~ i %}
+			<td  valign="top" class="">
+				<div class="cal_day">
+					{% set isEvent = __SELF__.isEvent(daynum|date("Y-m-d")) %}
+					{% if isEvent > 0 %}
+						<div class="daynum hasevent">
+							<a href="#modal-details-{{i}}" lass="call-modal">{{i}}</a>
+							<section class="pe-invite-content" id="modal-details-{{i}}" tabindex="-1"
+						        role="dialog" aria-labelledby="modal-label" aria-hidden="true">
+								<div class="pe-modal-inner">
+							        <header id="pe-modal-label">
+							        	<h2 id="pe-modal-label">{{'Event Details'|_}}</h2>
+							        </header>
+							        <div class="pe-modal-content">
+										{% for event_item in events %}
+											{% if daynum|date("Y-m-d") == event_item.event_date|date("Y-m-d") %}
+												<h4><a href="{{ eventpage|page({'event_slug': event_item.title|replace({' ':'-'})|lower,'event_id': event_item.id }) }}/" rel="pe_tooltip">{{ event_item.title }}</a>{% if event_item.status != '' %}<small class="event_{{event_item.status}}"> - {{event_item.status |_}}</small>{% endif %}</h4>
+												<h5>{{ event_item.event_date|date("M dS") }} -
+												{% if event_item.allday > 0 %}
+													{{'All Day'|_}}
+												{% else %}
+													{{ event_item.sttime|date("g:i a") }}  - {{ event_item.entime|date("g:i a") }}
+												{% endif %}
+												</h5>
+											{% endif %}
+										{% endfor %}
+							        </div>
+							        <footer>
+							        	<p>
+											<a href="#!" class="close-action btn btn-danger" title="Close this modal" data-dismiss="modal">{{'Close'|_}}</a>
+										</p>
+							        </footer>
+							    </div>
+
+			    				<a href="#!" class="pe-modal-close" title="Close this modal" data-close="Close"data-dismiss="modal">×</a>
+							</section>
+						</div>
+					{% else %}
+						{{i}}
+					{% endif %}
+				</div>
+			</td>
+			{% set daycount = daycount + 1 %}
+			{% if daycount > 7 %}
+				</tr><tr>
+				{% set daycount = 1 %}
+			{% endif %}
+		{% endfor %}
+
+		{% if (daycount - 7) > 0 %}
+			{% for i in i..(daycount - 7) %}
+				<td class='cal_blank'></td>
+				{% set daycount = daycount + 1 %}
+			{% endfor %}
+		{% elseif (daycount - 7) == 0 %}
+			<td class='cal_blank'></td>
+		{% endif %}
+	</tr>


### PR DESCRIPTION
Why:

* Override default markup

This change addresses the need by:

* Tested adding a custom button
`octobercms/themes/prismify-bootstrap-starterkit/partials/proEventCalendar/jquery_fullcalendar.htm`
* Working as intended